### PR TITLE
Dependency on shell-impl is not needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,6 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.forge.addon</groupId>
-         <artifactId>shell-impl</artifactId>
-         <scope>provided</scope>
-         <version>${furnace.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.forge.addon</groupId>
          <artifactId>ui</artifactId>
          <classifier>forge-addon</classifier>
          <scope>provided</scope>


### PR DESCRIPTION
Addons should never depend on impl modules
